### PR TITLE
Quern block now rotates on use

### DIFF
--- a/src/main/java/com/wtoll/simplequern/block/QuernBlock.java
+++ b/src/main/java/com/wtoll/simplequern/block/QuernBlock.java
@@ -10,12 +10,15 @@ import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.container.Container;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.item.ItemStack;
 import net.minecraft.sound.BlockSoundGroup;
 import net.minecraft.stat.Stats;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.BooleanProperty;
+import net.minecraft.state.property.DirectionProperty;
 import net.minecraft.util.ActionResult;
+import net.minecraft.util.BlockRotation;
 import net.minecraft.util.Hand;
 import net.minecraft.util.ItemScatterer;
 import net.minecraft.util.hit.BlockHitResult;
@@ -26,12 +29,13 @@ import net.minecraft.world.World;
 
 public class QuernBlock extends BlockWithEntity {
 
-    public static final BooleanProperty HANDSTONE;
+    public static final BooleanProperty HANDSTONE = BooleanProperty.of("handstone");
+    public static final DirectionProperty FACING = HorizontalFacingBlock.FACING;
     //TODO: Maybe add a thing for how rotated the handstone is that way it looks like its going around?
 
     public QuernBlock() {
         super(FabricBlockSettings.of(Material.STONE).nonOpaque().strength(3.5f, 3.5f).breakByTool(FabricToolTags.PICKAXES).sounds(BlockSoundGroup.STONE).build());
-        this.setDefaultState(this.stateManager.getDefaultState().with(HANDSTONE, false));
+        this.setDefaultState(this.stateManager.getDefaultState().with(HANDSTONE, false).with(FACING, Direction.NORTH));
     }
 
     @Override
@@ -98,11 +102,19 @@ public class QuernBlock extends BlockWithEntity {
     }
 
     @Override
-    protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
-        builder.add(HANDSTONE);
+    public BlockState getPlacementState(ItemPlacementContext ctx)
+    {
+        return getDefaultState().with(FACING, ctx.getPlayerFacing().getOpposite());
     }
 
-    static {
-        HANDSTONE =  BooleanProperty.of("handstone");
+    @Override
+    public BlockState rotate(BlockState state, BlockRotation rotation)
+    {
+        return state.with(FACING, rotation.rotate(state.get(FACING)));
+    }
+
+    @Override
+    protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
+        builder.add(HANDSTONE, FACING);
     }
 }

--- a/src/main/java/com/wtoll/simplequern/block/entity/QuernBlockEntity.java
+++ b/src/main/java/com/wtoll/simplequern/block/entity/QuernBlockEntity.java
@@ -5,6 +5,7 @@ import com.wtoll.simplequern.container.QuernContainer;
 import com.wtoll.simplequern.item.Handstone;
 import com.wtoll.simplequern.recipe.GrindingRecipe;
 import com.wtoll.simplequern.recipe.RecipeType;
+import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.LockableContainerBlockEntity;
 import net.minecraft.container.Container;
 import net.minecraft.container.PropertyDelegate;
@@ -22,8 +23,11 @@ import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
+import net.minecraft.util.BlockRotation;
 import net.minecraft.util.DefaultedList;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
+import net.minecraft.world.World;
 
 import java.util.Iterator;
 import java.util.Random;
@@ -101,6 +105,9 @@ public class QuernBlockEntity extends LockableContainerBlockEntity implements Si
             GrindingRecipe recipe = this.getWorld().getRecipeManager().getFirstMatch(RecipeType.GRINDING, this, this.world).orElse(null);
             if (this.canAcceptRecipeOutput(recipe)) {
                 this.grindTime++;
+
+                rotateClockwise(world, world.getBlockState(pos), pos);
+
                 if (this.grindTime > recipe.getGrindTime()) {
                     this.inventory.get(1).damage(1, player, (pp) -> {
                     });
@@ -112,6 +119,15 @@ public class QuernBlockEntity extends LockableContainerBlockEntity implements Si
             }
         }
         if (dirty) markDirty();
+    }
+
+    private void rotateClockwise(World world, BlockState state, BlockPos pos)
+    {
+        if (!state.rotate(BlockRotation.CLOCKWISE_90).canPlaceAt(world, pos))
+            return;
+
+        world.setBlockState(pos, state.rotate(BlockRotation.CLOCKWISE_90));
+        world.updateNeighbor(pos, state.getBlock(), pos);
     }
 
     protected boolean canAcceptRecipeOutput(Recipe<?> recipe) {

--- a/src/main/resources/assets/simplequern/blockstates/quern.json
+++ b/src/main/resources/assets/simplequern/blockstates/quern.json
@@ -1,6 +1,13 @@
 {
     "variants": {
-        "handstone=false":  { "model": "simplequern:block/quern" },
-        "handstone=true":  { "model": "simplequern:block/quern_handstone" }
+        "handstone=false,facing=north":  { "model": "simplequern:block/quern" },
+        "handstone=false,facing=east":  { "model": "simplequern:block/quern", "y": 90 },
+        "handstone=false,facing=south":  { "model": "simplequern:block/quern", "y": 180 },
+        "handstone=false,facing=west":  { "model": "simplequern:block/quern", "y": 270 },
+
+        "handstone=true,facing=north":  { "model": "simplequern:block/quern_handstone" },
+        "handstone=true,facing=east":  { "model": "simplequern:block/quern_handstone", "y": 90 },
+        "handstone=true,facing=south":  { "model": "simplequern:block/quern_handstone", "y": 180 },
+        "handstone=true,facing=west":  { "model": "simplequern:block/quern_handstone", "y": 270 }
     }
 }


### PR DESCRIPTION
The Quern block now rotates on use when a valid recipe is available